### PR TITLE
fix vercel routes for SSE

### DIFF
--- a/api/sse.ts
+++ b/api/sse.ts
@@ -21,7 +21,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const mcpServer = new AirtableMCPServer(airtableService);
 
     // Create SSE transport with the correct path for Vercel
-    const transport = new SSEServerTransport('/sse', res);
+    const transport = new SSEServerTransport('/api/sse', res);
 
     await mcpServer.connect(transport);
   } catch (err) {

--- a/vercel.json
+++ b/vercel.json
@@ -2,12 +2,14 @@
   "version": 2,
   "builds": [
     {
-      "src": "api/sse.ts",
+      "src": "api/*.ts",
       "use": "@vercel/node"
-    },
+    }
+  ],
+  "routes": [
     {
-      "src": "api/test.ts",
-      "use": "@vercel/node"
+      "src": "/api/(.*)",
+      "dest": "api/$1.ts"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- ensure serverless functions are built for all api TypeScript files
- route `/api/*` requests to matching TypeScript functions
- adjust SSE transport path to `/api/sse` for deployment

## Testing
- `npm test` *(fails: expected { Object (content, isError) } to match object { content: [ { …(3) } ], …(1) })*


------
https://chatgpt.com/codex/tasks/task_b_689e4d63c2c0832b96e5cdca9813bae3