### PR TITLE
fix: remove invalid handleMessage call

### DIFF
--- a/api/sse.ts
+++ b/api/sse.ts
@@ -205,10 +205,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     console.log('MCP connection established and ready for indefinite communication');
 
-    // Hand off the GET request to the transport to run the SSE stream
-    console.log('Starting SSE stream via transport.handleMessage...');
-    await transport.handleMessage(req);
-    console.log('SSE stream handler returned (connection likely closed by client).');
+    // Keep the request open until the client disconnects. The transport has
+    // already been started by the server connection above, so we simply wait
+    // indefinitely here.
+    await new Promise<void>(() => {});
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error('SSE handler error:', err);


### PR DESCRIPTION
## Summary
- avoid sending the request object to `handleMessage` in SSE handler
- keep SSE connection alive by awaiting an indefinite promise

## Testing
- `npm test` *(fails: No API key provided)*
- `npm run lint` *(fails: Parsing error: "parserOptions.project" has been provided for @typescript-eslint/parser)*

------
https://chatgpt.com/codex/tasks/task_b_689e9e6286f4832ba1b85c01e292620d